### PR TITLE
Added updated fix to issue 62

### DIFF
--- a/javascripts/pageControls.js
+++ b/javascripts/pageControls.js
@@ -4781,11 +4781,12 @@
 
 	//prompt user to save before redirecting to other page
 	window.addEventListener('beforeunload', function(e){
-		e.preventDefault(); 
-		if(ifEdited){
+		//e.preventDefault(); //this forces firefox to pop up 
+		if(ifEdited == true){
 			e.returnValue = "Hello"; 
 		}
-	})
+
+	}); 
 
 	
 


### PR DESCRIPTION
Removing e.preventDefault() prevents firefox to force popping up. 